### PR TITLE
Added the 'setenv' function.

### DIFF
--- a/include/dali/extern-definitions.h
+++ b/include/dali/extern-definitions.h
@@ -106,6 +106,8 @@ int clock_nanosleep( clockid_t clock_id, int flags, const struct timespec* reqtp
 
 int rand_r( unsigned int* seed );
 
+int setenv( const char* __name, const char* __value, int __replace );
+
 typedef size_t ssize_t;
 
 #endif // DALI_CORE_EXTERN_DEFINITIONS_H

--- a/src/extern-definitions.cpp
+++ b/src/extern-definitions.cpp
@@ -127,3 +127,20 @@ int rand_r( unsigned int* seed )
 
 	return rand();
 }
+
+int setenv( const char* __name, const char* __value, int __replace )
+{
+  int length = strlen(__name) + strlen(__value) + 1u;
+  char* envExpression = static_cast<char*>(malloc(length + 1u));
+  
+  strcpy(envExpression, __name);
+  strcat(envExpression, "=");
+  strcat(envExpression, __value);
+  envExpression[length] = '\0';
+
+  const bool result = _putenv( envExpression );
+
+  free(envExpression);
+
+  return result;
+}


### PR DESCRIPTION
* It has been removed from dali-adaptor as it's
  needed by dali-demo.

Signed-off-by: Victor Cebollada <v.cebollada@samsung.com>