### PR TITLE
libwebp added to build-deps script.

### DIFF
--- a/vcpkg-script/build-deps.sh
+++ b/vcpkg-script/build-deps.sh
@@ -17,6 +17,7 @@ pkg_list=( winsock2
 	   freetype
 	   harfbuzz
 	   fribidi
+	   libwebp
 	   dali-windows-dependencies
 	   dali-core
 	   dali-adaptor


### PR DESCRIPTION
* note! If vcpkg is already installed then there is no need to
  install the whole list of packages again. Just install the
  libwebp port

  $ ./vcpkg.exe install libwebp

Signed-off-by: Victor Cebollada <v.cebollada@samsung.com>