### PR TITLE
VS Studio projects update.

### DIFF
--- a/Solution/vc2017/dali-adaptor/dali-adaptor.vcxproj
+++ b/Solution/vc2017/dali-adaptor/dali-adaptor.vcxproj
@@ -54,7 +54,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\..\..\dali-core;..\..\..\..\dali-adaptor;..\..\..\..\dali-adaptor\third-party\windows-platform;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions) /NODEFAULTLIB:libcmt.lib /vmg</AdditionalOptions>
+      <AdditionalOptions>/vmg /wd4251</AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CallingConvention>Cdecl</CallingConvention>
@@ -101,7 +101,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\..\..\dali-core;..\..\..\..\dali-adaptor;..\..\..\..\dali-adaptor\third-party\windows-platform;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions) /NODEFAULTLIB:libcmt.lib /vmg</AdditionalOptions>
+      <AdditionalOptions>/vmg /wd4251</AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <CallingConvention>Cdecl</CallingConvention>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -206,6 +206,8 @@
     <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\adaptor\common\combined-update-render-controller.cpp" />
     <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\adaptor\generic\adaptor-impl-generic.cpp" />
     <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\adaptor\windows\framework-win.cpp" />
+    <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\addons\common\addon-manager.cpp" />
+    <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\addons\dummy\addon-manager-factory-dummy.cpp" />
     <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\clipboard\common\clipboard-event-notifier-impl.cpp" />
     <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\clipboard\generic\clipboard-impl-generic.cpp" />
     <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\graphics\gles\egl-context-helper-implementation.cpp" />

--- a/Solution/vc2017/dali-adaptor/dali-adaptor.vcxproj.filters
+++ b/Solution/vc2017/dali-adaptor/dali-adaptor.vcxproj.filters
@@ -613,6 +613,12 @@
     <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\system\windows\file-descriptor-monitor-windows.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\addons\common\addon-manager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\dali-adaptor\dali\internal\addons\dummy\addon-manager-factory-dummy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">

--- a/Solution/vc2017/dali-core/dali-core.vcxproj
+++ b/Solution/vc2017/dali-core/dali-core.vcxproj
@@ -54,7 +54,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\..\..\dali-core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions) /vmg /NODEFAULTLIB:libcmt.lib</AdditionalOptions>
+      <AdditionalOptions>/vmg /wd4251</AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CallingConvention>Cdecl</CallingConvention>
@@ -101,7 +101,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\..\..\dali-core;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions) /vmg /NODEFAULTLIB:libcmt.lib</AdditionalOptions>
+      <AdditionalOptions>/vmg /wd4251</AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <CallingConvention>Cdecl</CallingConvention>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -149,6 +149,7 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\animation\animation-data.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\animation\animation-devel.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\animation\path-constrainer.cpp" />
+    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\common\addon-binder.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\common\hash.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\common\singleton-service.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\common\stage-devel.cpp" />
@@ -162,6 +163,7 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\images\pixel-data-devel.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\object\handle-devel.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\object\csharp-type-registry.cpp" />
+    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\rendering\renderer-devel.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\scripting\scripting.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\signals\signal-delegate.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\threading\conditional-wait.cpp" />
@@ -170,6 +172,7 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\threading\thread.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\update\frame-callback-interface.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\update\update-proxy.cpp" />
+    <ClCompile Include="..\..\..\..\dali-core\dali\integration-api\addon-manager.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\integration-api\bitmap.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\integration-api\core.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\integration-api\debug.cpp" />

--- a/Solution/vc2017/dali-core/dali-core.vcxproj.filters
+++ b/Solution/vc2017/dali-core/dali-core.vcxproj.filters
@@ -805,6 +805,15 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\common\stage.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\dali-core\dali\integration-api\addon-manager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\common\addon-binder.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\rendering\renderer-devel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">

--- a/Solution/vc2017/dali-toolkit/dali-toolkit.vcxproj
+++ b/Solution/vc2017/dali-toolkit/dali-toolkit.vcxproj
@@ -54,7 +54,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\..\..\dali-core;..\..\..\..\dali-adaptor;..\..\..\..\dali-toolkit;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions) /vmg /NODEFAULTLIB:libcmt.lib</AdditionalOptions>
+      <AdditionalOptions>/vmg /wd4251</AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CallingConvention>Cdecl</CallingConvention>
@@ -103,7 +103,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\include;..\..\..\..\dali-core;..\..\..\..\dali-adaptor;..\..\..\..\dali-toolkit;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions) /vmg /NODEFAULTLIB:libcmt.lib</AdditionalOptions>
+      <AdditionalOptions>/vmg /wd4251</AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <CallingConvention>Cdecl</CallingConvention>
       <CompileAs>CompileAsCpp</CompileAs>


### PR DESCRIPTION
* AddOn files added to the projecs.

* Renderer devel file added to the project.

* Warning C4251 "'type' : class 'type1' needs to
  have dll-interface to be used by clients of class
  'type2'" ignored

* /NODEFAULTLIB option removed.

Signed-off-by: Victor Cebollada <v.cebollada@samsung.com>