### PR TITLE
Visual Studio dali-core project updated after patches:

### DIFF
--- a/Solution/vc2017/dali-core/dali-core.vcxproj
+++ b/Solution/vc2017/dali-core/dali-core.vcxproj
@@ -158,8 +158,6 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\common\stage.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\events\hit-test-algorithm.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\events\key-event-devel.cpp" />
-    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\events\rotation-gesture-detector.cpp" />
-    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\events\rotation-gesture.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\events\wheel-event-devel.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\images\distance-field.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\images\pixel-data-devel.cpp" />
@@ -238,7 +236,6 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\animation\linear-constrainer.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\animation\path.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\animation\time-period.cpp" />
-    <ClCompile Include="..\..\..\..\dali-core\dali\public-api\common\constants.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\common\dali-common.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\common\dali-vector.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\common\extents.cpp" />
@@ -248,6 +245,8 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\key-event.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\long-press-gesture.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\long-press-gesture-detector.cpp" />
+    <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\rotation-gesture-detector.cpp" />
+    <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\rotation-gesture.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\touch-event.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\wheel-event.cpp" />
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\pan-gesture.cpp" />

--- a/Solution/vc2017/dali-core/dali-core.vcxproj.filters
+++ b/Solution/vc2017/dali-core/dali-core.vcxproj.filters
@@ -79,9 +79,6 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\public-api\signals\connection-tracker-interface.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\dali-core\dali\public-api\common\constants.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\dali-core\dali\internal\event\animation\constrainer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -751,12 +748,6 @@
     <ClCompile Include="..\..\..\..\dali-core\dali\internal\event\events\tap-gesture\tap-gesture-recognizer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\events\rotation-gesture.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\dali-core\dali\devel-api\events\rotation-gesture-detector.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\dali-core\dali\internal\event\events\rotation-gesture\rotation-gesture-detector-impl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -821,6 +812,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\dali-core\dali\internal\event\rendering\vertex-buffer-impl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\rotation-gesture-detector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\dali-core\dali\public-api\events\rotation-gesture.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
    * Moved RotationGesture to the Public API.
    * Changed const variables to constexpr where possible.

Signed-off-by: Victor Cebollada <v.cebollada@samsung.com>